### PR TITLE
Created add-post page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ export const App: React.FC = () => {
     title: 'Zhang Xian Kai',
     description: 'To my coolest grandpa',
     bgImage: 'https://images.unsplash.com/photo-1528289504374-36139e80ef6f?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80',
+    uuid: 'zhang-xian-kai-325a6d28-f686-4353-b976-bd7168587d95',
   };
 
   return (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,6 +4,8 @@ import {jsx, SxStyleProp} from 'theme-ui';
 import {Link} from 'react-router-dom';
 import {BsPlusCircleFill} from 'react-icons/bs';
 
+export const HEADER_HEIGHT_PX = 54
+
 /**
  * This is the navigation bar that always stay at the top of the webpage for desktop views.
  * On mobile, it won't stick to the top of the screen, meaning it'll only stay on the top
@@ -27,7 +29,7 @@ export const Navigation: React.FC = () => {
 
   // The style of the navbar's main wrapper.
   const wrapperStyle: SxStyleProp = {
-    height: '54px',
+    height: HEADER_HEIGHT_PX,
     width: '100vw',
     px: '5%',
     color: 'primary',

--- a/src/components/addpost/PostForm.tsx
+++ b/src/components/addpost/PostForm.tsx
@@ -1,0 +1,12 @@
+/** @jsx jsx */
+
+import React from 'react';
+import { jsx, SxStyleProp } from 'theme-ui';
+
+export interface PostFormProps {
+  
+}
+ 
+export const PostForm: React.FC<PostFormProps> = () => {
+  return (<div></div>);
+}

--- a/src/components/addpost/PostPostForm.tsx
+++ b/src/components/addpost/PostPostForm.tsx
@@ -21,6 +21,9 @@ export const PostPostForm: React.FC<PostPostProps> = () => {
   const [message, setMessage] = useState<string>("");
   const [photo, setPhoto] = useState<File>(null);
 
+  /**
+   * Handles the submission of the form. Also makes sure (from the React side) that a post does not have no message or photo.
+   */
   const handleSubmit = (event: React.FormEvent<HTMLButtonElement>) => {
     if (message == "" && photo == null) {
       alert("Either a message or photo must be present!");

--- a/src/components/addpost/PostPostForm.tsx
+++ b/src/components/addpost/PostPostForm.tsx
@@ -1,0 +1,77 @@
+/** @jsx jsx */
+
+import React, {useState, useContext} from "react";
+import {jsx, SxStyleProp} from "theme-ui";
+
+import {BoardContext, IBoardContext} from "../../utils/context";
+
+export interface PostPostProps {}
+
+/**
+ * A component containing the add post form in order to add a new
+ * post to a board.
+ *
+ * The form embedded in this component will send all requests to
+ * `api/board/posts/create` in order to create a post.
+ */
+export const PostPostForm: React.FC<PostPostProps> = () => {
+  const board = useContext<IBoardContext>(BoardContext);
+
+  const [author, setAuthor] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
+  const [photo, setPhoto] = useState<File>(null);
+
+  const handleSubmit = (event: React.FormEvent<HTMLButtonElement>) => {
+    if (message == "" && photo == null) {
+      alert("Either a message or photo must be present!");
+      event.preventDefault();
+
+      return;
+    }
+
+    // temp
+    alert("submitted!");
+    event.preventDefault();
+  };
+
+  return (
+    <div>
+      <form action='/api/board/posts/create' method='post'>
+        <fieldset>
+          <label htmlFor='author'>Author:</label>
+          <input
+            type='text'
+            name='name'
+            id='author'
+            onChange={(e) => setAuthor(e.target.value)}
+          />
+        </fieldset>
+
+        <fieldset>
+          <label htmlFor='message'>Message:</label>
+          <input
+            type='text'
+            name='message'
+            id='message'
+            onChange={(e) => setMessage(e.target.value)}
+          />
+        </fieldset>
+
+        <fieldset>
+          <label htmlFor='photo'>Photo:</label>
+          <input
+            type='file'
+            accept='image/*'
+            name='author'
+            id='author'
+            onChange={(e) => setPhoto(e.target.files[0])}
+          />
+        </fieldset>
+
+        <button type='submit' onClick={handleSubmit}>
+          Submit!
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/pages/AddPost.tsx
+++ b/src/pages/AddPost.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import {jsx, SxStyleProp} from 'theme-ui';
 
 import { BoardContext, IBoardContext } from '../utils/context';
@@ -20,40 +20,18 @@ import { PostPostForm } from '../components/addpost/PostPostForm'
 export const AddPost: React.FC = () => {
   const board = useContext<IBoardContext>(BoardContext);
 
-  const [windowHeight, setWindowHeight] = useState<number>(window.innerHeight)
-
-  /**
-   * Changes this add post page's height.
-   */
-  const adjustHeight = () => {
-    setWindowHeight(window.innerHeight)
-  }
-
-  // TODO: figure out more efficient way of making sure the main body is the
-  // right height.
-  // Account for window resizing so that the page and image eight is correct
-  useEffect(() => {
-    window.addEventListener('resize', adjustHeight)
-
-    return () => {
-      window.removeEventListener('resize', adjustHeight)
-    }
-  }, [])
-
   const wrapperStyle: SxStyleProp = {
-    variant: 'bodyWrapper',
+    pt: [0, HEADER_HEIGHT_PX],
+    pb: [HEADER_HEIGHT_PX, 0],
     overflow: 'hidden',
     display: 'flex',
     flexDirection: 'row',
-
-    // Since the header height is a constant px amount, height should be the
-    // height of the window minus constant
-    height: windowHeight - HEADER_HEIGHT_PX,
+    minHeight: '100vh',
   };
 
   const photoStyle: SxStyleProp = {
     width: '30%',
-    height: '100%',
+    height: 'auto',
     backgroundImage: `linear-gradient(#EDEDED99, #EDEDED99), url(${board.bgImage})`,
     backgroundSize: 'cover',
   }

--- a/src/pages/AddPost.tsx
+++ b/src/pages/AddPost.tsx
@@ -8,28 +8,29 @@ import { HEADER_HEIGHT_PX } from '../components/Navigation'
 /**
  * This is the page that allows the user to add a new post.
  * 
- * The post may contain a name, message, or images.
+ * The post may contain a name, message, or an image.
  * The name is optional, but at least either of the message or image must exist
  * for a successful form submission.
  * 
- * It also displays a preview of the photos once they are uploaded.
+ * A preview of the photo is also presented once uploaded.
  * 
  * @returns The add-post page. 
  */
 export const AddPost: React.FC = () => {
   const board = useContext<IBoardContext>(BoardContext);
 
-  const [height, setHeight] = useState<number>(window.innerHeight)
+  const [windowHeight, setWindowHeight] = useState<number>(window.innerHeight)
 
   /**
    * Changes this add post page's height.
    */
   const adjustHeight = () => {
-    setHeight(window.innerHeight)
+    setWindowHeight(window.innerHeight)
   }
 
   // TODO: figure out more efficient way of making sure the main body is the
   // right height.
+  // Account for window resizing so that the page and image eight is correct
   useEffect(() => {
     window.addEventListener('resize', adjustHeight)
 
@@ -40,10 +41,13 @@ export const AddPost: React.FC = () => {
 
   const wrapperStyle: SxStyleProp = {
     variant: 'bodyWrapper',
-    height: height - HEADER_HEIGHT_PX,
     overflow: 'hidden',
     display: 'flex',
     flexDirection: 'row',
+
+    // Since the header height is a constant px amount, height should be the
+    // height of the window minus constant
+    height: windowHeight - HEADER_HEIGHT_PX,
   };
 
   const photoStyle: SxStyleProp = {
@@ -62,7 +66,7 @@ export const AddPost: React.FC = () => {
     <div sx={wrapperStyle}>
       <div sx={photoStyle} />
       <div sx={formContainerStyle}>
-        // FORM COMPONENT GOES HERE
+        {/* FORM COMPONENT GOES HERE */}
       </div>
     </div>
   );

--- a/src/pages/AddPost.tsx
+++ b/src/pages/AddPost.tsx
@@ -4,6 +4,7 @@ import {jsx, SxStyleProp} from 'theme-ui';
 
 import { BoardContext, IBoardContext } from '../utils/context';
 import { HEADER_HEIGHT_PX } from '../components/Navigation'
+import { PostPostForm } from '../components/addpost/PostPostForm'
 
 /**
  * This is the page that allows the user to add a new post.
@@ -66,7 +67,7 @@ export const AddPost: React.FC = () => {
     <div sx={wrapperStyle}>
       <div sx={photoStyle} />
       <div sx={formContainerStyle}>
-        {/* FORM COMPONENT GOES HERE */}
+        <PostPostForm />
       </div>
     </div>
   );

--- a/src/pages/AddPost.tsx
+++ b/src/pages/AddPost.tsx
@@ -1,6 +1,9 @@
 /** @jsx jsx */
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {jsx, SxStyleProp} from 'theme-ui';
+
+import { BoardContext, IBoardContext } from '../utils/context';
+import { HEADER_HEIGHT_PX } from '../components/Navigation'
 
 /**
  * This is the page that allows the user to add a new post.
@@ -14,14 +17,53 @@ import {jsx, SxStyleProp} from 'theme-ui';
  * @returns The add-post page. 
  */
 export const AddPost: React.FC = () => {
+  const board = useContext<IBoardContext>(BoardContext);
+
+  const [height, setHeight] = useState<number>(window.innerHeight)
+
+  /**
+   * Changes this add post page's height.
+   */
+  const adjustHeight = () => {
+    setHeight(window.innerHeight)
+  }
+
+  // TODO: figure out more efficient way of making sure the main body is the
+  // right height.
+  useEffect(() => {
+    window.addEventListener('resize', adjustHeight)
+
+    return () => {
+      window.removeEventListener('resize', adjustHeight)
+    }
+  }, [])
 
   const wrapperStyle: SxStyleProp = {
     variant: 'bodyWrapper',
+    height: height - HEADER_HEIGHT_PX,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'row',
   };
+
+  const photoStyle: SxStyleProp = {
+    width: '30%',
+    height: '100%',
+    backgroundImage: `linear-gradient(#EDEDED99, #EDEDED99), url(${board.bgImage})`,
+    backgroundSize: 'cover',
+  }
+
+  const formContainerStyle: SxStyleProp = {
+    width: '70%',
+    height: '100%',
+  }
 
   return (
     <div sx={wrapperStyle}>
-      This is the add post page.
+      <div sx={photoStyle} />
+      <div sx={formContainerStyle}>
+        // FORM COMPONENT GOES HERE
+      </div>
     </div>
   );
 };

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -7,10 +7,12 @@ export interface IBoardContext {
   title: string;
   description: string;
   bgImage: string;
+  uuid: string;
 }
 
 export const BoardContext = React.createContext<IBoardContext>({
   title: 'HOME',
   description: '',
   bgImage: '',
+  uuid: '',
 });

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,3 +1,5 @@
+import { HEADER_HEIGHT_PX } from '../components/Navigation'
+
 /**
  * The theme used throughout the app.
  * Visit https://theme-ui.com/theme-spec for more info.
@@ -30,8 +32,8 @@ export const theme = {
     dropshadow: '#00000040',
   },
   bodyWrapper: {
-    mt: [0, '54px'],
-    mb: ['54px', 0],
+    mt: [0, HEADER_HEIGHT_PX],
+    mb: [HEADER_HEIGHT_PX, 0],
   },
   fontSizes: {
     mini: 10,


### PR DESCRIPTION
Closes #9.

This page will allow users to add posts to the board. A form will be provided for the user to submit to an API endpoint to save a post. This form will be accessible on both mobile and desktop.

To-do list partially adapted from #9 :
- [x] Create foundation for the add-post page
- [x] Create a form asking for name, message, and a photo.
- [x] Error validation if the user didn't fill out both the message + photo field
- [ ] Make the form responsive on mobile site
- [ ] Redirect to home page after adding it
- [ ] Send request to correct API endpoint and request the new post from the server 

Once the backend connection is complete, this page can send request to the correct API endpoint.


